### PR TITLE
MNT: Update for conda-build 3

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -1,1 +1,11 @@
-{}
+cxx_compiler:
+- toolchain_cxx
+glib:
+- '2.55'
+pin_run_as_build:
+  glib:
+    max_pin: x.x
+  xz:
+    max_pin: x.x
+xz:
+- '5.2'

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -1,6 +1,17 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+cxx_compiler:
+- toolchain_cxx
+glib:
+- '2.55'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+pin_run_as_build:
+  glib:
+    max_pin: x.x
+  xz:
+    max_pin: x.x
+xz:
+- '5.2'

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,6 +4,11 @@ set -ex
 export CFLAGS="${CFLAGS} -O3"
 export CXXFLAGS="${CXXFLAGS} -O3"
 
+if [ "$(uname)" == "Linux" ]; then
+  # need to enable C++11 on linux explicitly
+  export CXXFLAGS="${CXXFLAGS} -std=c++11"
+fi
+
 # configure, make, install, check
 sed -e '/^libdocdir =/ s/$(book_name)/glibmm-'"${PKG_VERSION}"'/' \
     docs/Makefile.in > docs/Makefile.in.new

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,6 +6,7 @@ export CXXFLAGS="${CXXFLAGS} -O3"
 
 if [ "$(uname)" == "Linux" ]; then
   # need to enable C++11 on linux explicitly
+  export CFLAGS="${CFLAGS} -std=c++11"
   export CXXFLAGS="${CXXFLAGS} -std=c++11"
 fi
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -ex
 
-export CFLAGS="-O3"
-export CXXFLAGS="-O3"
+export CFLAGS="${CFLAGS} -O3"
+export CXXFLAGS="${CXXFLAGS} -O3"
 
 # configure, make, install, check
 sed -e '/^libdocdir =/ s/$(book_name)/glibmm-'"${PKG_VERSION}"'/' \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,20 +1,8 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 
 export CFLAGS="-O3"
 export CXXFLAGS="-O3"
-if [ "$(uname)" == "Darwin" ]; then
-  # for Mac OSX
-  export CC=clang
-  export CXX=clang++
-  export MACOSX_VERSION_MIN="10.7"
-  export MACOSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
-  export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
-  export CXXFLAGS="${CXXFLAGS} -stdlib=libc++"
-  export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
-  export LDFLAGS="${LDFLAGS} -stdlib=libc++ -lc++"
-  export LINKFLAGS="${LDFLAGS}"
-fi
 
 # configure, make, install, check
 sed -e '/^libdocdir =/ s/$(book_name)/glibmm-'"${PKG_VERSION}"'/' \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set major_minor = "2.54" %}
+{% set major_minor = "2.52" %}
 {% set version = major_minor + ".1" %}
-{% set sha256 = "7cc28c732b04d70ed34f0c923543129083cfb90580ea4a2b4be5b38802bf6a4a" %}
+{% set sha256 = "dc19d20fb6b24d6b6da7cbe1b2190b38ae6ad64e6b93fecdcce71b995f43c975" %}
 {% if linux %}
     {% set libext = ".so" %}
 {% else %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set major_minor = "2.48" %}
-{% set version = major_minor + ".1" %}
-{% set sha256 = "dc225f7d2f466479766332483ea78f82dc349d59399d30c00de50e5073157cdf" %}
+{% set major_minor = "2.56" %}
+{% set version = major_minor + ".0" %}
+{% set sha256 = "6e74fcba0d245451c58fc8a196e9d103789bc510e1eee1a9b1e816c5209e79a9" %}
 {% if linux %}
     {% set libext = ".so" %}
 {% else %}
@@ -17,7 +17,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 4
+  number: 0
   skip: true  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
   build:
     - make
     - pkg-config
+    - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
     - libsigcpp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set major_minor = "2.56" %}
-{% set version = major_minor + ".0" %}
-{% set sha256 = "6e74fcba0d245451c58fc8a196e9d103789bc510e1eee1a9b1e816c5209e79a9" %}
+{% set major_minor = "2.54" %}
+{% set version = major_minor + ".1" %}
+{% set sha256 = "7cc28c732b04d70ed34f0c923543129083cfb90580ea4a2b4be5b38802bf6a4a" %}
 {% if linux %}
     {% set libext = ".so" %}
 {% else %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,17 +17,21 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win]
 
 requirements:
   build:
+    - make
     - pkg-config
     - {{ compiler('cxx') }}
   host:
     - libsigcpp
     - glib
     - xz
+  run:
+    - libsigcpp
+    - glib
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,9 +23,11 @@ build:
 requirements:
   build:
     - pkg-config
+    - {{ compiler('cxx') }}
+  host:
     - libsigcpp
-    - glib 2.51.*
-    - xz 5.2.*
+    - glib
+    - xz
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,9 @@ test:
 
 about:
   home: http://www.gtkmm.org
-  license: GNU Lesser General Public License v2.1
+  license: LGPL v2.1
+  license_family: GPL
+  license_file: COPYING
   summary: "This is glibmm, a C++ API for parts of glib that are useful for C++."
 
 extra:


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've updated the recipe for conda-build 3 as instructed in #7.

List of changes done to the recipe:
Renamed build with host
Moving pkg-config from host to build
Removing pinnings for glib to use values from conda_build_config.yaml. If you need the pin see [here](https://conda-forge.org/docs/meta.html#pinning-packages) for details.
Removing pinnings for xz to use values from conda_build_config.yaml. If you need the pin see [here](https://conda-forge.org/docs/meta.html#pinning-packages) for details.
Adding C++ compiler


Here's a checklist to do before merging.
- [ ] Bump the build number if needed.

Fixes #7